### PR TITLE
Feature/add tagname

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,7 +68,7 @@ func init() {
 	viper.BindPFlag("bindir", rootCmd.PersistentFlags().Lookup("bindir"))
 	viper.SetDefault("bindir", "$HOME/.local/bin")
 	viper.BindPFlag("definitions", rootCmd.PersistentFlags().Lookup("definitions"))
-	viper.SetDefault("definitions", "https://cellpointmobile.github.io/vk-definitions/vk-definitions.json")
+	viper.SetDefault("definitions", "https://raw.githubusercontent.com/cellpointmobile/vk-definitions/master/vk-definitions.json")
 
 	glogcobra.Init(rootCmd)
 }

--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,5 @@ require (
 	github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51 // indirect
 	golang.org/x/oauth2 v0.0.0-20190220154721-9b3c75971fc9
 )
+
+go 1.13


### PR DESCRIPTION
Because Kustomize has started publishing multiple programs from their github repo, we need to be able to specify a partial tagname to be able to grab just the CLI.
This PR adds the field "TagName" to definitions and adds code to find latest version through tags that start with /TagName/. If a TagName is specified, the release which contains the found latest version tag will be used. This also takes PreRelease into account to find the correct release.